### PR TITLE
priority-scheduler : Done

### DIFF
--- a/threads/synch.c
+++ b/threads/synch.c
@@ -100,6 +100,7 @@ sema_up (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	sema->value++;
+	list_sort(&sema->waiters, sema_priority_more, NULL);
 	if (!list_empty (&sema->waiters)) {
 		struct thread *th = list_entry (list_front (&sema->waiters), struct thread, elem);
 		thread_unblock (list_entry (list_pop_front (&sema->waiters), struct thread, elem));


### PR DESCRIPTION
+) sema-up 에서 sema-waiters 의 thread 를 뽑아오기 전에 list_sort 를 해야함.